### PR TITLE
update jnifty to v0.6, sync jsonlab to git20220313, fieldtrip/fieldtrip#1991

### DIFF
--- a/external/jnifti/README.md
+++ b/external/jnifti/README.md
@@ -1,19 +1,19 @@
 # JNIfTI Toolbox - Fast and portable NIfTI-1/2 reader and NIfTI-to-JNIfTI converter
 
-* Copyright (C) 2019  Qianqian Fang <q.fang at neu.edu>
+* Copyright (C) 2019-2020  Qianqian Fang <q.fang at neu.edu>
 * License: GNU General Public License version 3 (GPL v3) or Apache License 2.0, see License*.txt
-* Version: 0.5 (Ascendence)
+* Version: 0.6 (Epica)
 * URL: http://github.com/fangq/jnifti
 
 ## Overview
 
 This is a fully functional NIfTI-1/2 reader/writer that supports both 
 MATLAB and GNU Octave, and is capable of reading/writing both non-compressed 
-and compressed NIfTI files (.nii, .nii.gz) as well as two-part Analyze7.5/NIfTI
-files (.hdr/.img and .hdr.gz/.img.gz).
+and compressed NIfTI files (`.nii, .nii.gz`) as well as two-part Analyze7.5/NIfTI
+files (`.hdr/.img` and `.hdr.gz/.img.gz`).
 
 More importantly, this is a toolbox that converts NIfTI data to its JSON-based
-replacement, JNIfTI (.jnii for text-based and .bnii for binary-based), defined
+replacement, JNIfTI (`.jnii` for text-based and `.bnii` for binary-based), defined
 by the JNIfTI specification (http://github.com/fangq/jnifti). JNIfTI is a 
 much more flexible, human-readable and extensible file format compared to the
 more rigid and opaque NIfTI format, making the data much easier to manipulate
@@ -29,7 +29,7 @@ utilizes `memmapfile`-based disk-reading, making it very fast. For Octave,
 `memmapfile` is currently not implemented, so, a full reading is required.
 
 The JNIfTI toolbox is also capable of reading/writing gzip-compressed NIfTI and 
-Analyze7.5 files (.nii.gz, .hdr.gz, .img.gz). This feature is supported in MATLAB
+Analyze7.5 files (`.nii.gz, .hdr.gz, .img.gz`). This feature is supported in MATLAB
 directly without needing another toolbox (MATLAB must be in the JVM-enabled mode).
 
 To process gzip-compressed NIfTI/Analyze files in Octave and MATLAB with `-nojvm`,
@@ -41,7 +41,7 @@ MATLAB and Octave. They can be downloaded at
 
 To save NIfTI-1/2 data as JNIfTI files, one needs to install JSONLab. The JNIfTI
 data format supports internal compression (as oppose to external compression such
-as \*.gz files). To create or read compressed JNIfTI files in Octave, one must 
+as `*.gz` files). To create or read compressed JNIfTI files in Octave, one must 
 install the ZMat toolbox, as listed above.
 
 ## Usage
@@ -80,4 +80,12 @@ Example:
   jnii=jnifticreate(uint8(magic(10)),'Name','10x10 magic matrix');
   savejnifti(jnii, 'magic10.jnii');
   savejnifti(jnii, 'magic10_debug.bnii','Compression','gzip');
+```
+### `jnii2nii` - To convert a JNIfTI file or data structure to a NIfTI-1/2 file
+Example:
+```
+  nii=jnii2nii('test.jnii');             % read a .jnii file as an nii structure
+  nii=jnii2nii('test.bnii');             % read a .bnii file as an nii structure
+  jnii2nii('test.jnii', 'newdata.nii.gz'); % read a text-JNIfTI file to an .nii.gz file
+  jnii2nii('test.bnii', 'newdata.nii'); % read a text-JNIfTI file to an .nii file
 ```

--- a/external/jnifti/jnifticreate.m
+++ b/external/jnifti/jnifticreate.m
@@ -26,7 +26,7 @@ function jnii=jnifticreate(varargin)
 %
 
 
-jnii=struct('NIFTIHeader',struct(), 'NIFTIData', []);
+jnii=struct(encodevarname('_DataInfo_'),struct(),'NIFTIHeader',struct(), 'NIFTIData', []);
 
 % jnii.NIFTIHeader.NIIHeaderSize=  0;
 % jnii.NIFTIHeader.A75DataTypeName=   'uint8';
@@ -75,6 +75,19 @@ jnii.NIFTIHeader.Affine(3,:)=    [0 0 1 0];
 jnii.NIFTIHeader.Name=           'default';
 jnii.NIFTIHeader.NIIFormat=      'jnifti';
 % jnii.NIFTIHeader.NIIExtender=    [0,0,0,0];
+
+datainfo.JNIFTIVersion='0.5';
+datainfo.Comment='Created by JNIFTY Toolbox (https://github.com/NeuroJSON/jnifty)';
+datainfo.AnnotationFormat='https://github.com/NeuroJSON/jnifti/blob/master/JNIfTI_specification.md';
+datainfo.SerialFormat='http://json.org';
+datainfo.Parser=struct('Python',[], ...
+                       'MATLAB',[], ...
+                       'JavaScript', 'https://github.com/NeuroJSON/jsdata',...
+                       'CPP', 'https://github.com/NeuroJSON/json',...
+                       'C', 'https://github.com/NeuroJSON/ubj');
+datainfo.Parser.Python={'https://pypi.org/project/jdata','https://pypi.org/project/bjdata'};
+datainfo.Parser.MATLAB={'https://github.com/NeuroJSON/jnifty','https://github.com/NeuroJSON/jsonlab'};
+jnii.(encodevarname('_DataInfo_'))=datainfo;
 
 if(nargin==0)
     return;

--- a/external/jnifti/loadjnifti.m
+++ b/external/jnifti/loadjnifti.m
@@ -15,7 +15,7 @@ function jnii=loadjnifti(filename, varargin)
 %                *.jnii for text JNIfTI file
 %                *.nii  for NIFTI-1/2 files
 %        options: (optional) if loading from a .bnii file, please see the options for
-%               loadubjson.m (part of JSONLab); if loading from a .jnii, please see the 
+%               loadbj.m (part of JSONLab); if loading from a .jnii, please see the 
 %               supported options for loadjson.m (part of JSONLab).
 %
 %    output:
@@ -51,7 +51,7 @@ if(regexp(filename,'\.nii$'))
 elseif(regexp(filename,'\.jnii$'))
     jnii=loadjson(filename,varargin{:});
 elseif(regexp(filename,'\.bnii$'))
-    jnii=loadubjson(filename,varargin{:});
+    jnii=loadbj(filename,varargin{:});
 else
     error('file suffix must be .jnii for text JNIfTI, .bnii for binary JNIfTI or .nii for NIFTI-1/2 files');
 end

--- a/external/jnifti/memmapstream.m
+++ b/external/jnifti/memmapstream.m
@@ -1,4 +1,4 @@
-function outstruct=memmapstream(bytes, format)
+function outstruct=memmapstream(bytes, format, varargin)
 %
 %    outstruct=memmapstream(bytes, format)
 %
@@ -58,11 +58,22 @@ bytes=bytes(:)';
 
 datatype=struct('int8',1,'int16',2,'int32',4,'int64',8,'uint8',1,'uint16',2,'uint32',4,'uint64',8,'single',4,'double',8);
 
-outstruct=struct();
+opt=varargin2struct(varargin{:});
+opt.usemap=jsonopt('usemap',0,opt) && exist('containers.Map');
+
+if(opt.usemap)
+    outstruct=containers.Map();
+else
+    outstruct=struct();
+end
 len=1;
 for i=1:size(format,1)
     bytelen=datatype.(format{i,1})*prod(format{i,2});
-    outstruct.(format{i,3})=reshape(typecast(uint8(bytes(len:bytelen+len-1)),format{i,1}),format{i,2});
+    if(opt.usemap)
+        outstruct(format{i,3})=reshape(typecast(uint8(bytes(len:bytelen+len-1)),format{i,1}),format{i,2});
+    else
+        outstruct.(format{i,3})=reshape(typecast(uint8(bytes(len:bytelen+len-1)),format{i,1}),format{i,2});
+    end
     len=len+bytelen;
     if(len>length(bytes))
         break;

--- a/external/jnifti/nii2jnii.m
+++ b/external/jnifti/nii2jnii.m
@@ -25,7 +25,7 @@ function nii=nii2jnii(filename, format, varargin)
 %               file name - *.jnii for text-based JNIfTI, or *.bnii for the 
 %               binary version
 %        options: (optional) if saving to a .bnii file, please see the options for
-%               saveubjson.m (part of JSONLab); if saving to .jnii, please see the 
+%               savebj.m (part of JSONLab); if saving to .jnii, please see the 
 %               supported options for savejson.m (part of JSONLab).
 %
 %    output:
@@ -338,7 +338,7 @@ if(nargout==0 && strcmp(format,'nii')==0 && strcmp(format,'jnii')==0)
     if(regexp(format,'\.jnii$'))
         savejson('',nii,'FileName',format,varargin{:});
     elseif(regexp(format,'\.bnii$'))
-        saveubjson('',nii,'FileName',format,varargin{:});
+        savebj('',nii,'FileName',format,varargin{:});
     else
         error('file suffix must be .jnii for text JNIfTI or .bnii for binary JNIfTI');
     end

--- a/external/jnifti/savebnii.m
+++ b/external/jnifti/savebnii.m
@@ -20,7 +20,7 @@ function savebnii(jnii, filename, varargin)
 %                jnii.NIFTIExtension - a cell array contaiing the extension data buffers
 %        filename: the output file name to the binary-JNIfTI file (.bnii)
 %        options: (optional) if saving to .bnii, please see the 
-%               supported options for saveubjson.m (part of JSONLab).
+%               supported options for savebj.m (part of JSONLab).
 %
 %    example:
 %        jnii=jnifticreate(uint8(magic(10)),'Name','10x10 magic matrix');
@@ -36,8 +36,8 @@ if(nargin<2)
     error('you must provide data and output file name');
 end
 
-if(~exist('saveubjson','file'))
+if(~exist('savebj','file'))
     error('you must first install JSONLab from http://github.com/fangq/jsonlab/');
 end
 
-saveubjson('',jnii,'FileName',filename,varargin{:});
+savebj('',jnii,'FileName',filename,varargin{:});

--- a/external/jnifti/savejnifti.m
+++ b/external/jnifti/savejnifti.m
@@ -22,7 +22,7 @@ function savejnifti(jnii, filename, varargin)
 %                *.bnii for binary JNIfTI file
 %                *.jnii for text JNIfTI file
 %        options: (optional) if saving to a .bnii file, please see the options for
-%               saveubjson.m (part of JSONLab); if saving to .jnii, please see the 
+%               savebj.m (part of JSONLab); if saving to .jnii, please see the 
 %               supported options for savejson.m (part of JSONLab).
 %
 %    example:

--- a/external/jsonlab/loadbj.m
+++ b/external/jsonlab/loadbj.m
@@ -153,7 +153,7 @@ function [data, mmap] = loadbj(fname,varargin)
             case {'S','C','H','i','U','I','u','l','m','L','M','h','d','D','T','F','Z','N'}
                 [data{jsoncount}, pos] = parse_value(inputstr, pos, [], opt);
             otherwise
-                error_pos('Outer level structure must be an object or an array', inputstr, pos);
+                error_pos('Root level structure must start with a valid marker "{[SCHiUIulmLMhdDTFZN"', inputstr, pos);
         end
         if(jsoncount>=maxobjid)
             break;

--- a/external/jsonlab/savejson.m
+++ b/external/jsonlab/savejson.m
@@ -23,7 +23,7 @@ function json=savejson(rootname,obj,varargin)
 %           opt can have the following fields (first in [.|.] is the default)
 %
 %           FileName [''|string]: a file name to save the output JSON data
-%           FloatFormat ['%.10g'|string]: format to show each numeric element
+%           FloatFormat ['%.16g'|string]: format to show each numeric element
 %                         of a 1D/2D array;
 %           IntFormat ['%.0f'|string]: format to display integer elements
 %                         of a 1D/2D array;
@@ -152,7 +152,7 @@ opt.formatversion=jsonopt('FormatVersion',3,opt);
 opt.compressarraysize=jsonopt('CompressArraySize',100,opt);
 opt.compressstringsize=jsonopt('CompressStringSize',opt.compressarraysize*4,opt);
 opt.intformat=jsonopt('IntFormat','%.0f',opt);
-opt.floatformat=jsonopt('FloatFormat','%.10g',opt);
+opt.floatformat=jsonopt('FloatFormat','%.16g',opt);
 opt.unpackhex=jsonopt('UnpackHex',1,opt);
 opt.arraytostruct=jsonopt('ArrayToStruct',0,opt);
 opt.parselogical=jsonopt('ParseLogical',0,opt);

--- a/fileio/private/ft_hastoolbox.m
+++ b/fileio/private/ft_hastoolbox.m
@@ -15,7 +15,7 @@ function [status] = ft_hastoolbox(toolbox, autoadd, silent)
 % silent = 0 means that it will give some feedback about adding the toolbox
 % silent = 1 means that it will not give feedback
 
-% Copyright (C) 2005-2019, Robert Oostenveld
+% Copyright (C) 2005-2022, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -114,6 +114,7 @@ url = {
   'ITAB'                                  'contact Stefania Della Penna'
   'JSONIO'                                'see https://github.com/gllmflndn/JSONio'
   'JSONLAB'                               'see https://se.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files'
+  'JNIFTI'                                'see https://github.com/NeuroJSON/jnifti'
   'LAGEXTRACTION'                         'see https://github.com/agramfort/eeglab-plugin-ieee-tbme-2010'
   'MARS'                                  'see http://www.parralab.org/mars'
   'MATLAB2BESA'                           'see http://www.besa.de/downloads/matlab/ and get the "MATLAB to BESA Export functions"'
@@ -394,6 +395,8 @@ switch toolbox
     dependency = {'extractlag' 'perform_realign'};
   case 'JSONLAB'
     dependency = {'loadjson' 'savejson'};
+  case 'JNIFTI'
+    dependency = {'loadjnifti' 'savejnifti'};
   case 'PLOTLY'
     dependency = {'fig2plotly' 'savejson'};
   case 'JSONIO'

--- a/forward/private/ft_hastoolbox.m
+++ b/forward/private/ft_hastoolbox.m
@@ -15,7 +15,7 @@ function [status] = ft_hastoolbox(toolbox, autoadd, silent)
 % silent = 0 means that it will give some feedback about adding the toolbox
 % silent = 1 means that it will not give feedback
 
-% Copyright (C) 2005-2019, Robert Oostenveld
+% Copyright (C) 2005-2022, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -114,6 +114,7 @@ url = {
   'ITAB'                                  'contact Stefania Della Penna'
   'JSONIO'                                'see https://github.com/gllmflndn/JSONio'
   'JSONLAB'                               'see https://se.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files'
+  'JNIFTI'                                'see https://github.com/NeuroJSON/jnifti'
   'LAGEXTRACTION'                         'see https://github.com/agramfort/eeglab-plugin-ieee-tbme-2010'
   'MARS'                                  'see http://www.parralab.org/mars'
   'MATLAB2BESA'                           'see http://www.besa.de/downloads/matlab/ and get the "MATLAB to BESA Export functions"'
@@ -394,6 +395,8 @@ switch toolbox
     dependency = {'extractlag' 'perform_realign'};
   case 'JSONLAB'
     dependency = {'loadjson' 'savejson'};
+  case 'JNIFTI'
+    dependency = {'loadjnifti' 'savejnifti'};
   case 'PLOTLY'
     dependency = {'fig2plotly' 'savejson'};
   case 'JSONIO'

--- a/inverse/private/ft_hastoolbox.m
+++ b/inverse/private/ft_hastoolbox.m
@@ -15,7 +15,7 @@ function [status] = ft_hastoolbox(toolbox, autoadd, silent)
 % silent = 0 means that it will give some feedback about adding the toolbox
 % silent = 1 means that it will not give feedback
 
-% Copyright (C) 2005-2019, Robert Oostenveld
+% Copyright (C) 2005-2022, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -114,6 +114,7 @@ url = {
   'ITAB'                                  'contact Stefania Della Penna'
   'JSONIO'                                'see https://github.com/gllmflndn/JSONio'
   'JSONLAB'                               'see https://se.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files'
+  'JNIFTI'                                'see https://github.com/NeuroJSON/jnifti'
   'LAGEXTRACTION'                         'see https://github.com/agramfort/eeglab-plugin-ieee-tbme-2010'
   'MARS'                                  'see http://www.parralab.org/mars'
   'MATLAB2BESA'                           'see http://www.besa.de/downloads/matlab/ and get the "MATLAB to BESA Export functions"'
@@ -394,6 +395,8 @@ switch toolbox
     dependency = {'extractlag' 'perform_realign'};
   case 'JSONLAB'
     dependency = {'loadjson' 'savejson'};
+  case 'JNIFTI'
+    dependency = {'loadjnifti' 'savejnifti'};
   case 'PLOTLY'
     dependency = {'fig2plotly' 'savejson'};
   case 'JSONIO'

--- a/plotting/private/ft_hastoolbox.m
+++ b/plotting/private/ft_hastoolbox.m
@@ -15,7 +15,7 @@ function [status] = ft_hastoolbox(toolbox, autoadd, silent)
 % silent = 0 means that it will give some feedback about adding the toolbox
 % silent = 1 means that it will not give feedback
 
-% Copyright (C) 2005-2019, Robert Oostenveld
+% Copyright (C) 2005-2022, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -114,6 +114,7 @@ url = {
   'ITAB'                                  'contact Stefania Della Penna'
   'JSONIO'                                'see https://github.com/gllmflndn/JSONio'
   'JSONLAB'                               'see https://se.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files'
+  'JNIFTI'                                'see https://github.com/NeuroJSON/jnifti'
   'LAGEXTRACTION'                         'see https://github.com/agramfort/eeglab-plugin-ieee-tbme-2010'
   'MARS'                                  'see http://www.parralab.org/mars'
   'MATLAB2BESA'                           'see http://www.besa.de/downloads/matlab/ and get the "MATLAB to BESA Export functions"'
@@ -394,6 +395,8 @@ switch toolbox
     dependency = {'extractlag' 'perform_realign'};
   case 'JSONLAB'
     dependency = {'loadjson' 'savejson'};
+  case 'JNIFTI'
+    dependency = {'loadjnifti' 'savejnifti'};
   case 'PLOTLY'
     dependency = {'fig2plotly' 'savejson'};
   case 'JSONIO'


### PR DESCRIPTION
@robertoostenveld, I found two errors after running `test_issue1991.m`, 

- first, the error of parsing the .bnii file was caused by the fact that jnifty toolbox `external/jnifty` was an old release (v0.5) (where `loadubjson` was used instead of `loadbj`), 
- after fixing the above error, I got a second error in the the first assert statement - this is because `loadjson` function was an old version from `external/iso2mesh`

the first issue should be resolved with this PR.

to fix the second issue, I want to hear you opinion first - because both jsonlab and jnifty have been developed as part of iso2mesh. 

- one choice you have is to remove `external/jnifty` and `external/jsonlab` and update `external/iso2mesh` to the git version. The pro side of this approach is that there is no duplication; the con-side is reduced modularity, and also the needs for testing if iso2mesh were to be updated (not sure how many functions have dependencies)
- the second approach is to either ensure that addpath to `external/jnifty` and `external/jsonlab` happens after addpath to `external/iso2mesh`, or remove the duplicated functions in iso2mesh - the downside of doing this is that some iso2mesh functions that depends on these two sub-packages may not work (although I am not sure if it matters for fieldtrip).

Please let me know which way you prefer to manage these external packages. I will add to this PR with additional updates.